### PR TITLE
Adventure mode on symlink'd map folders

### DIFF
--- a/src/main/java/com/onarandombox/MultiverseAdventure/MVAdventureWorld.java
+++ b/src/main/java/com/onarandombox/MultiverseAdventure/MVAdventureWorld.java
@@ -538,8 +538,8 @@ public final class MVAdventureWorld implements AdventureWorld {
             // 2. Remove it
             File serverFolder = plugin.getServer().getWorldContainer();
             File worldFile = new File(serverFolder, name);
-            FileUtils.deleteFolder(worldFile);
-            if (worldFile.exists()) {
+            FileUtils.deleteFolderContents(worldFile);
+            if (worldFile.list().length > 0) {
                 // WTF? Couldn't delete it???
                 plugin.log(Level.SEVERE, "Couldn't delete a world!");
                 MVAResetListener.removeResettingWorld(getName());


### PR DESCRIPTION
This change allows symlinks to be used for the map folders. We use this on our server so that we can have some maps on RamDisk, thus providing faster access for users.

Example setup (overly simplified, but gives the concept)

```
drwxr-xr-x  5 username group     4096 Jan  1 16:35 lnktest/
lrwxrwxrwx  1 username group        7 Jan  1 16:31 test -> lnktest/
drwxr-xr-x  5 username group     4096 Jan  1 14:35 test.template/
```
